### PR TITLE
remove extra comma from changedConfigContents, fixes compile error

### DIFF
--- a/bin/react-scripts-x.js
+++ b/bin/react-scripts-x.js
@@ -85,7 +85,7 @@ function changeAndReturnWebpackConfig(pathToConfig, postcssPlugins) {
 
     postcssPlugins.map(plugin => {
       if (plugin.config) {
-        return `require('${plugin.name}')(${JSON.stringify(plugin.config)}),`;
+        return `require('${plugin.name}')(${JSON.stringify(plugin.config)})`;
       }
 
       return `require('${plugin.name}')`;


### PR DESCRIPTION
When adding "config" for postcss plugins, extra commas were appending, which generated invalid JSON.

e.g. `require('postcss-easy-import'),require('postcss-cssnext')({"browsers":[">1%","last 4 versions"]}),,require('postcss-reporter')({"clearMessages":true}),`