### PR TITLE
generalize for using react-script-x with other plugins

### DIFF
--- a/bin/react-scripts-x.js
+++ b/bin/react-scripts-x.js
@@ -1,26 +1,53 @@
 #!/usr/bin/env node
 'use strict';
+const crypto = require('crypto');
+const path = require('path');
+const fs = require('fs');
+const equal = require('deep-equal');
+const spawn = require('cross-spawn');
+const args = process.argv.slice(2);
 
-const crypto  = require('crypto');
-const path    = require('path');
-const fs      = require('fs');
-const equal   = require('deep-equal');
-const spawn   = require('cross-spawn');
-const args    = process.argv.slice(2);
+const appDirectory = fs.realpathSync(process.cwd());
+const appDescriptor = require(path.resolve(appDirectory, 'package'));
+const extensionsConfig = appDescriptor['react-scripts-x'];
 
-const appDirectory            = fs.realpathSync(process.cwd());
-const appDescriptor           = require(path.resolve(appDirectory, 'package'));
-const extensionsConfig        = appDescriptor['react-scripts-x'];
-const reactScriptsDir         = path.dirname(require.resolve('react-scripts/package'));
-const reactScriptsDescriptor  = require('react-scripts/package');
-const moduleDescriptor        = require('react-scripts-x/package');
+let reactScriptsDir;
+let reactScriptName;
+
+if (path.dirname(require.resolve('react-scripts-ts/package'))) {
+  reactScriptsDir = path.dirname(require.resolve('react-scripts-ts/package'));
+  reactScriptName = 'react-scripts-ts';
+} else if (path.dirname(require.resolve('react-scripts/package'))) {
+  reactScriptsDir = path.dirname(require.resolve('react-scripts/package'));
+  reactScriptName = 'react-scripts';
+} else {
+  throw new Error('react-scripts package not found');
+}
+const reactScriptsDescriptor = require(`${reactScriptName}/package`);
+const moduleDescriptor = require('react-scripts-x/package');
 
 const pathTo = {
-  webpackDevConfig:           path.resolve(reactScriptsDir, 'config', 'webpack.config.dev.js'),
-  webpackProdConfig:          path.resolve(reactScriptsDir, 'config', 'webpack.config.prod.js'),
-  webpackDevOriginalConfig:   path.resolve(reactScriptsDir, 'config', 'webpack.config.dev.original.js'),
-  webpackProdOriginalConfig:  path.resolve(reactScriptsDir, 'config', 'webpack.config.prod.original.js'),
-  changeLog:                  path.resolve(reactScriptsDir, 'react-scripts-x.json')
+  webpackDevConfig: path.resolve(
+    reactScriptsDir,
+    'config',
+    'webpack.config.dev.js'
+  ),
+  webpackProdConfig: path.resolve(
+    reactScriptsDir,
+    'config',
+    'webpack.config.prod.js'
+  ),
+  webpackDevOriginalConfig: path.resolve(
+    reactScriptsDir,
+    'config',
+    'webpack.config.dev.original.js'
+  ),
+  webpackProdOriginalConfig: path.resolve(
+    reactScriptsDir,
+    'config',
+    'webpack.config.prod.original.js'
+  ),
+  changeLog: path.resolve(reactScriptsDir, 'react-scripts-x.json')
 };
 
 function findArrayEnd(string, start) {
@@ -56,7 +83,9 @@ function changeAndReturnWebpackConfig(pathToConfig, postcssPlugins) {
     fs.writeFileSync(pathToConfig + '.original', configContents, 'utf8');
   }
 
-  const postcssBlockStart = configContents.indexOf("require.resolve('postcss-loader')");
+  const postcssBlockStart = configContents.indexOf(
+    "require.resolve('postcss-loader')"
+  );
 
   if (postcssBlockStart < 0) {
     console.error(`Failed to parse Webpack config: ${pathToConfig}`);
@@ -64,14 +93,20 @@ function changeAndReturnWebpackConfig(pathToConfig, postcssPlugins) {
   }
 
   const pluginArrayStartString = 'plugins: () => [';
-  const pluginArrayStart = configContents.indexOf(pluginArrayStartString, postcssBlockStart);
+  const pluginArrayStart = configContents.indexOf(
+    pluginArrayStartString,
+    postcssBlockStart
+  );
 
   if (pluginArrayStart < 0) {
     console.error(`Failed to parse Webpack config: ${pathToConfig}`);
     return configContents;
   }
 
-  const pluginArrayEnd = findArrayEnd(configContents, pluginArrayStart + pluginArrayStartString.length - 1);
+  const pluginArrayEnd = findArrayEnd(
+    configContents,
+    pluginArrayStart + pluginArrayStartString.length - 1
+  );
 
   if (pluginArrayEnd < 0) {
     console.error(`Failed to parse Webpack config: ${pathToConfig}`);
@@ -79,20 +114,16 @@ function changeAndReturnWebpackConfig(pathToConfig, postcssPlugins) {
   }
 
   const changedConfigContents =
-    configContents.slice(0, pluginArrayEnd)
+    configContents.slice(0, pluginArrayEnd) +
+    postcssPlugins
+      .map(plugin => {
+        if (plugin.config) {
+          return `require('${plugin.name}')(${JSON.stringify(plugin.config)})`;
+        }
 
-    +
-
-    postcssPlugins.map(plugin => {
-      if (plugin.config) {
-        return `require('${plugin.name}')(${JSON.stringify(plugin.config)})`;
-      }
-
-      return `require('${plugin.name}')`;
-    }).join()
-
-    +
-
+        return `require('${plugin.name}')`;
+      })
+      .join() +
     configContents.slice(pluginArrayEnd);
 
   fs.writeFileSync(pathToConfig, changedConfigContents, 'utf8');
@@ -100,67 +131,92 @@ function changeAndReturnWebpackConfig(pathToConfig, postcssPlugins) {
   return changedConfigContents;
 }
 
-function applyExtensions() {
-  console.info('Applying extensions');
-
+function applyExtensions(extension) {
   const files = {};
 
-  [
-    pathTo.webpackDevConfig,
-    pathTo.webpackProdConfig
-  ].forEach(file => {
+  [pathTo.webpackDevConfig, pathTo.webpackProdConfig].forEach(file => {
     files[path.relative(reactScriptsDir, file)] = {
-      hash: md5(changeAndReturnWebpackConfig(file, extensionsConfig.postcss)),
+      hash: md5(changeAndReturnWebpackConfig(file, extension)),
       changes: extensionsConfig
     };
   });
 
-  fs.writeFileSync(pathTo.changeLog, JSON.stringify({
-    version: {
-      'react-scripts': reactScriptsDescriptor.version,
-      'react-scripts-x': moduleDescriptor.version
-    },
-    files: files
-  }, null, 2), 'utf8');
+  fs.writeFileSync(
+    pathTo.changeLog,
+    JSON.stringify(
+      {
+        version: {
+          [reactScriptName]: reactScriptsDescriptor.version,
+          'react-scripts-x': moduleDescriptor.version
+        },
+        files: files
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
 }
 
-if (extensionsConfig && extensionsConfig.postcss) {
-  if (fs.existsSync(pathTo.changeLog)) {
-    const changeLog = require(pathTo.changeLog);
+if (extensionsConfig) {
+  try {
+    Object.values(extensionsConfig).map(extension => {
+      if (!extension) {
+        throw new Error('No webpack plugin');
+      }
+      if (fs.existsSync(pathTo.changeLog)) {
+        const changeLog = require(pathTo.changeLog);
 
-    if (changeLog.version['react-scripts'] !== reactScriptsDescriptor.version) {
-      applyExtensions();
-    } else if (changeLog.version['react-scripts-x'] !== moduleDescriptor.version) {
-      applyExtensions();
-    } else if (Object.keys(changeLog.files)
-        .filter(file => equal(changeLog.files[file].changes, extensionsConfig))
-        .filter(file => changeLog.files[file].hash === md5(fs.readFileSync(path.resolve(reactScriptsDir, file), 'utf8')))
-        .length !== Object.keys(changeLog.files).length) {
-      applyExtensions();
-    }
-  } else {
-    applyExtensions();
+        if (
+          changeLog.version[reactScriptName] !== reactScriptsDescriptor.version
+        ) {
+          applyExtensions(extension);
+        } else if (
+          changeLog.version['react-scripts-x'] !== moduleDescriptor.version
+        ) {
+          applyExtensions(extension);
+        } else if (
+          Object.keys(changeLog.files)
+            .filter(file =>
+              equal(changeLog.files[file].changes, extensionsConfig)
+            )
+            .filter(
+              file =>
+                changeLog.files[file].hash ===
+                md5(
+                  fs.readFileSync(path.resolve(reactScriptsDir, file), 'utf8')
+                )
+            ).length !== Object.keys(changeLog.files).length
+        ) {
+          applyExtensions(extension);
+        }
+      } else {
+        applyExtensions(extension);
+      }
+    });
+  } catch (error) {
+    throw new Error(error);
   }
 }
 
 const result = spawn.sync(
   'node',
-  [require.resolve('react-scripts/bin/react-scripts')].concat(args),
+  [require.resolve(`${reactScriptName}/bin/${reactScriptName}`)].concat(args),
   { stdio: 'inherit' }
 );
 
 if (result.signal) {
   if (result.signal === 'SIGKILL') {
-    console.log(
+    console.info(
       'The build failed because the process exited too early. ' +
-      'This probably means the system ran out of memory or someone called ' +
-      '`kill -9` on the process.'
+        'This probably means the system ran out of memory or someone called ' +
+        '`kill -9` on the process.'
     );
   } else if (result.signal === 'SIGTERM') {
-    console.log(
+    console.info(
       'The build failed because the process exited too early. ' +
-      'Someone might have called `kill` or `killall`, or the system could ' +
-      'be shutting down.'
+        'Someone might have called `kill` or `killall`, or the system could ' +
+        'be shutting down.'
     );
   }
 


### PR DESCRIPTION
Hello,
I made a little modification that I feel is needed. 
I wanted to use Typescript and your plugin works just well.

This is what I have in my package.json

```"react-scripts-x": {
    "postcss": [
      {
        "name": "postcss-custom-properties",
        "config": {
          "preserve": true
        }
      },
      {
        "name": "autoprefixer"
      },
      {
        "name": "postcss-calc"
      },
      {
        "name": "postcss-inline-svg",
        "config": {
          "path": "public/images"
        }
      },
      {
        "name": "precss"
      }
    ],
    "ts-loader": {
      "mode": "development",
      "devtool": "inline-source-map",
      "entry": "./src/index.ts",
      "output": {
        "filename": "bundle.js"
      },
      "resolve": {
        "extensions": [
          ".ts",
          ".tsx",
          ".js"
        ]
      },
      "module": {
        "rules": [
          {
            "test": "/\\.tsx?$/",
            "loader": "ts-loader"
          }
        ]
      }
    }
  },```


I don't have any errors so far, I also debugged to see if any data is actually received passed to the involved function.
Could you please confirm that it is ok?
